### PR TITLE
Distributed buffer global dofs

### DIFF
--- a/include/HighPerMeshes/dsl/buffers/BufferBase.hpp
+++ b/include/HighPerMeshes/dsl/buffers/BufferBase.hpp
@@ -46,12 +46,11 @@ namespace HPM
         const auto& GetDofs() const { return dofs; }
 
         template <std::size_t Dimension>
-        auto GetDofIndices(const std::size_t entity_index = 0) const -> std::vector<std::size_t>
+        auto GetDofIndices(const std::size_t entity_index = 0UL) const -> std::vector<std::size_t>
         {
             // Global dofs are the same for all entities.
-            assert(Dimension != (MeshT::CellDimension + 1) || (Dimension == (MeshT::CellDimension + 1) && entity_index == 0));
-
-            const std::size_t offset = offsets[Dimension] + entity_index * dofs.template At<Dimension>();
+            const std::size_t index = (Dimension == (MeshT::CellDimension + 1) ? 0UL : entity_index);
+            const std::size_t offset = offsets[Dimension] + index * dofs.template At<Dimension>();
             std::vector<std::size_t> indices(dofs.template At<Dimension>());
 
             for (std::size_t i = 0; i < indices.size(); ++i)

--- a/include/HighPerMeshes/dsl/buffers/DistributedBuffer.hpp
+++ b/include/HighPerMeshes/dsl/buffers/DistributedBuffer.hpp
@@ -47,6 +47,7 @@ namespace HPM
         DistributedBuffer(const std::size_t L1_index, MeshT const& mesh, const DofT dofs = DofT{}, Allocator const allocator = Allocator{}) : Base(mesh, dofs.Get()), data(allocator)
         {
             //! For each entity in the local range go through all DoF-Dimensions and the corresponding indices and assign them a position in the local buffer space.
+            const std::size_t num_global_dofs = dofs.template At<MeshT::CellDimension + 1>();
             std::size_t local_index = dofs.template At<MeshT::CellDimension + 1>(); // global dofs first
 
             ::HPM::auxiliary::ConstexprFor<0, MeshT::CellDimension + 1>([this, &mesh, &dofs, L1_index, &local_index](const auto Dimension) mutable {
@@ -66,7 +67,7 @@ namespace HPM
                 }
             });
 
-            data.resize(global_to_local_index.size());
+            data.resize(num_global_dofs + global_to_local_index.size());
         }
 
         //! \return Given an index, return the corresponding buffer entry
@@ -165,6 +166,10 @@ namespace HPM
         }
 
         auto GetSize() { return data.size(); }
+
+        auto begin() const { return data.begin(); }
+
+        auto end() const { return data.end(); }
 
       private:
         using Base::mesh;


### PR DESCRIPTION
There was a bug regarding the `data` member size: the number of global dofs at the beginning of the `data` member was not considered.

I also added begin() and end() member functions.